### PR TITLE
fixed passing in multiple additional args:

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var tmpDynamoLocalDirDest = path.join(os.tmpdir(), 'dynamodb-local'),
             if (!additionalArgs) {
                 additionalArgs = [];
             }
-            else if (Array.isArray(additionalArgs)) {
+            else if (!Array.isArray(additionalArgs)) {
                 additionalArgs = [additionalArgs];
             }
 


### PR DESCRIPTION
FIXED: DynamoDbLocal.launch dynamoLocalPort, null, ["-sharedDb", "-cors", "'*'"]

I was a little confused by the line I fixed. It wraps another array around the additionalArgs if, and only if, it is already an array. I'm guessing this line was intended to accept a single string argument and convert it into an array - thus I added a "!" in front. This also solve my problem - I wanted to pass in multiple args.
