### PR TITLE
Update broken download URL (move to https), add installer configuration method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,35 @@
 # dynamodb-local
 
-A wrapper for AWS DynamoDB Local, intended for use in testcases.  Will automatically download the files needed to run DynamoDb Local. 
+A wrapper for AWS DynamoDB Local, intended for use in testcases. 
+Will automatically download the files needed to run DynamoDb Local. 
+
+You can optionally override the download URL from where it fetches the installation archive
+as well as the target directory to which it will install the binaries (default is your system's temp folder).
+
 
 # Usage
 
+Install the module as development dependency by running
+
 `npm install dynamodb-local --save-dev`
 
-Then in node:
+Then in node, write your test script like this:
 
 ```javascript
 var DynamoDbLocal = require('dynamodb-local');
+var dynamoLocalPort = 8000;
 
-DynamoDbLocal.launch(dynamoLocalPort, null, ['-sharedDb']); //if you want to share with Javascript Shell
-//Do your tests
-DynamoDbLocal.stop(8000);
+DynamoDbLocal.launch(dynamoLocalPort, null, ['-sharedDb']) //if you want to share with Javascript Shell
+    .then(function () {
+    
+        // do your tests
+        
+        DynamoDbLocal.stop(dynamoLocalPort);
+    });
 ```
 
-See [AWS DynamoDB Docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html) for more info on how to interact with DynamoDB Local.
+Another example which also shows how to override the installer configuration can be found in 
+[examples/simple.js](examples/simple.js).
+
+See [AWS DynamoDB Docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html) 
+for more info on how to interact with DynamoDB Local.

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -2,12 +2,18 @@
 
 var DynamoDbLocal = require('../index');
 
+// optional config customization - default is your OS' temp directory and an Amazon server from US West
+DynamoDbLocal.configureInstaller({
+    installPath: './dynamodblocal-bin',
+    dowloadUrl: 'https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/dynamodb_local_latest.tar.gz'
+});
+
 DynamoDbLocal.launch(8000)
     .then(function (ChildProcess) {
-      console.log("PID created: ", ChildProcess.pid);
+        console.log('PID created: ', ChildProcess.pid);
 
-      //do your tests
+        //do your tests
 
-      DynamoDbLocal.stop(8000);
-      console.log('finished');
+        DynamoDbLocal.stop(8000);
+        console.log('finished');
     });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var os = require('os'),
     spawn = require('child_process').spawn,
@@ -65,12 +65,12 @@ var tmpDynamoLocalDirDest = path.join(os.tmpdir(), 'dynamodb-local'),
                         stdio: ['pipe', 'pipe', process.stderr]
                     });
 
-                    if (!child.pid) throw new Error("Unable to launch DynamoDBLocal process");
+                    if (!child.pid) throw new Error('Unable to launch DynamoDBLocal process');
 
                     child
                         .on('error', function (err) {
-                            if (verbose) console.log("local DynamoDB start error", err);
-                            throw new Error("Local DynamoDB failed to start. ");
+                            if (verbose) console.log('local DynamoDB start error', err);
+                            throw new Error('Local DynamoDB failed to start. ');
                         })
                         .on('close', function (code) {
                             if (code !== null && code !== 0) {
@@ -80,7 +80,7 @@ var tmpDynamoLocalDirDest = path.join(os.tmpdir(), 'dynamodb-local'),
 
                     runningProcesses[port] = child;
 
-                    if (verbose) console.log("DynamoDbLocal(" + child.pid + ") started on port", port, "via java", args.join(' '), "from CWD", tmpDynamoLocalDirDest);
+                    if (verbose) console.log('DynamoDbLocal(' + child.pid + ') started on port', port, 'via java', args.join(' '), 'from CWD', tmpDynamoLocalDirDest);
 
                     return child;
                 });
@@ -100,7 +100,7 @@ var tmpDynamoLocalDirDest = path.join(os.tmpdir(), 'dynamodb-local'),
 module.exports = DynamoDbLocal;
 
 function installDynamoDbLocal() {
-    console.log("Checking for ", tmpDynamoLocalDirDest);
+    console.log('Checking for ', tmpDynamoLocalDirDest);
     var deferred = Q.defer();
 
     try {
@@ -112,14 +112,14 @@ function installDynamoDbLocal() {
     } catch (e) {
     }
 
-    console.log("DynamoDb Local not installed. Installing...");
+    console.log('DynamoDb Local not installed. Installing...');
 
     if (!fs.existsSync(tmpDynamoLocalDirDest))
         fs.mkdirSync(tmpDynamoLocalDirDest);
 
     http.get('http://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz', function (redirectResponse) {
         if (200 != redirectResponse.statusCode) {
-            deferred.reject(new Error("Error getting DynamoDb local latest tar.gz location " + response.headers['location'] + ": " + redirectResponse.statusCode));
+            deferred.reject(new Error('Error getting DynamoDb local latest tar.gz location ' + response.headers['location'] + ': ' + redirectResponse.statusCode));
         }
         redirectResponse
         .pipe(zlib.Unzip())

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "dynamodb-local",
   "description": "A wrapper for AWS DynamoDB Local, intended for use in testcases",
-  "version": "0.0.14",
+  "version": "0.0.15",
+  "license": "MIT",
   "repository": "doapp-ryanp/dynamodb-local",
   "author": {
     "name": "Ryan Pendergast",


### PR DESCRIPTION
Amazon seems to have disabled their http download links and moved to https exclusively.
Therefore I replaced the http module with https and fixed the default download link.

Additionally I made the download URL configurable through an additional `configureInstaller` method.
Now users of the module can possibly fix broken links in the future in their own projects or set a regional or custom server if they want to. 
They can also specify a custom installation path where the module will look for the DynamoDB-Local binaries or install them if needed, which allows e.g. installing them directly in the project directory instead of cluttering the system temp.
Both options together would even give you the theoretical ability to use different DynamoDB-Local versions for different projects at the same time.

I also added a `license` field to the `package.json`, because according to https://docs.npmjs.com/files/package.json#license the `licenses` field you used is deprecated and no longer recognized by `npm`.