### PR TITLE
Fix typo in config object in examples/simple.js

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -5,7 +5,7 @@ var DynamoDbLocal = require('../index');
 // optional config customization - default is your OS' temp directory and an Amazon server from US West
 DynamoDbLocal.configureInstaller({
     installPath: './dynamodblocal-bin',
-    dowloadUrl: 'https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/dynamodb_local_latest.tar.gz'
+    downloadUrl: 'https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/dynamodb_local_latest.tar.gz'
 });
 
 DynamoDbLocal.launch(8000)


### PR DESCRIPTION
Excuse me please, I just spotted a little typo I made in the [`simple.js`](https://github.com/ByteCommander/dynamodb-local/blob/master/examples/simple.js#L8).
In line 8, it must be `downloadUrl` and not `dowloadUrl`, of course. 

Anyway, thanks for your immediate reaction and approvement.