### PR TITLE
Kill child on process.exit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,10 @@ var runningProcesses = {},
                             }
                         });
 
+                    process.on('exit', function() {
+                        child.kill();
+                    })
+
                     runningProcesses[port] = child;
 
                     if (verbose) {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ var runningProcesses = {},
 
                     process.on('exit', function() {
                         child.kill();
-                    })
+                    });
 
                     runningProcesses[port] = child;
 


### PR DESCRIPTION
Otherwise the java process stays around after running a node program
like this:

```js
  const DynamoDbLocal = require('dynamodb-local');
  DynamoDbLocal.launch(8001, null, ['-sharedDb', '-inMemory'])
    .then(function() {
      process.exit(0);
    })
```

which happens in the wild. For example, some test frameworks behaves
like this when in so called watch mode and you type 'q' as in 'quit'.