### PR TITLE
Restructure Typescript bindings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,12 @@
 import { ChildProcess } from 'child_process';
 
-declare module 'dynamodb-local' {
-  type argValues = '-cors' | '-dbPath' | '-delayTransientStatuses' | '-help' | '-inMemory' | '-optimizeDbBeforeStartup' | '-port' | '-sharedDb';
+type argValues = '-cors' | '-dbPath' | '-delayTransientStatuses' | '-help' | '-inMemory' | '-optimizeDbBeforeStartup' | '-port' | '-sharedDb';
 
-  export interface InstallerConfig {
-    installPath: string;
-    downloadUrl: string;
-  }
-
-  namespace DynamoDbLocal {}
-
-  export class DynamoDbLocal {
-    static configureInstaller(config: InstallerConfig): void;
-    static launch(portNumber: number, dbPath: string | null, args: argValues[], verbose?: boolean): Promise<ChildProcess>;
-    static stop(portNumber: number): void;
-  }
-
-  export = DynamoDbLocal;
+export interface InstallerConfig {
+  installPath: string;
+  downloadUrl: string;
 }
+
+export function configureInstaller(config: InstallerConfig): void;
+export function launch(portNumber: number, dbPath?: string | null, args?: argValues[], verbose?: boolean): Promise<ChildProcess>;
+export function stop(portNumber: number): void;


### PR DESCRIPTION
Restructures the current typescript bindings, removing the module wrapper.

The current typings fail with "error TS2666: Exports and export assignments are not permitted in module augmentations".  I don't think a module wrapper is necessary for index.d.ts files included with source files  (c.f. [redux typings](https://github.com/reactjs/redux/blob/master/index.d.ts)).  