### PR TITLE
Addition of detachment flag to parameter set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dynamodb-local
 
-A wrapper for AWS DynamoDB Local, intended for use in testcases. 
-Will automatically download the files needed to run DynamoDb Local. 
+A wrapper for AWS DynamoDB Local, intended for use in testcases.
+Will automatically download the files needed to run DynamoDb Local.
 
 You can optionally override the download URL from where it fetches the installation archive
 as well as the target directory to which it will install the binaries (default is your system's temp folder).
@@ -16,20 +16,35 @@ Install the module as development dependency by running
 Then in node, write your test script like this:
 
 ```javascript
-var DynamoDbLocal = require('dynamodb-local');
-var dynamoLocalPort = 8000;
+const DynamoDbLocal = require('dynamodb-local');
+const dynamoLocalPort = 8000;
 
 DynamoDbLocal.launch(dynamoLocalPort, null, ['-sharedDb']) //if you want to share with Javascript Shell
     .then(function () {
-    
+
         // do your tests
-        
+
         DynamoDbLocal.stop(dynamoLocalPort);
     });
 ```
 
-Another example which also shows how to override the installer configuration can be found in 
+Alternatively if you wish to use this as detached server like this:
+
+```javascript
+
+const DynamoDbLocal = require('dynamodb-local');
+const dynamoLocalPort = 8000;
+
+const child = await DynamoDbLocal.launch(dynamoLocalPort, null, [], false, true); // must be wrapped in async function
+
+// do your tests
+
+await DynamoDbLocal.stopChild(child); // must be wrapped in async function
+
+```
+
+Another example which also shows how to override the installer configuration can be found in
 [examples/simple.js](examples/simple.js).
 
-See [AWS DynamoDB Docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html) 
+See [AWS DynamoDB Docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html)
 for more info on how to interact with DynamoDB Local.


### PR DESCRIPTION
To kill a detached dynamodb, use the stopChild command with the child.
Highly recommended to use the async await functionality from ES8+ as it
saves a lengthy promise chains.
Fixed the verbose flag, to default to false
Fixed a type on the child.close that stated start instead of close
Added -Xrs flag to be able to kill the child without running into exit
code 143.