### PR TITLE
workaround around a syntax mystery

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ var os = require('os'),
     zlib = require('zlib'),
     path = require('path'),
     mkdirp = require('mkdirp'),
-    Q = require('q'),
-    debug = require('debug')('dynamodb-local');
+    Q = require('q');
+
+var debugLib = require('debug');
+var debug = debugLib('dynamodb-local');
 
 var JARNAME = 'DynamoDBLocal.jar';
 


### PR DESCRIPTION
Hi,  

I've joined a new company with node projects and when I've included dynamodb-local as a dependency I receive an ReferenceError on this line. 

I'm not sure why this error crops up, but it does and this fixes it. I've raised as a patch as if it's happening in the projects I've come on to, it may be happening to others.

ReferenceError: debug is not defined
      1 | 'use strict'
      2 | 
    > 3 | const DynamoDbLocal = require('dynamodb-local');
      4 | const dynamoLocalPort = 8000;
      5 | 
      at Object.<anonymous> (node_modules/dynamodb-local/index.js:12:11)
      at Object.<anonymous> (test/unit-tests/libs/health-check-unit-test.js:3:23)

