### PR TITLE
Make relaunch signature match launch

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,9 @@ var runningProcesses = {},
                 child.kill();
             }
         },
-        relaunch: function (port, db) {
+        relaunch: function (port, ...args) {
             this.stop(port);
-            this.launch(port, db);
+            this.launch(port, ...args);
         },
         configureInstaller: function (conf) {
             if (conf.installPath) {


### PR DESCRIPTION
Passes all arguments from relaunch on to launch.
Useful if you're using arguments such as -sharedDb as it saves having to the manual stop / launch.