### PR TITLE
Mark Config options as optional in TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,8 @@ import { ChildProcess } from 'child_process';
 type argValues = '-cors' | '-dbPath' | '-delayTransientStatuses' | '-help' | '-inMemory' | '-optimizeDbBeforeStartup' | '-port' | '-sharedDb';
 
 export interface InstallerConfig {
-  installPath: string;
-  downloadUrl: string;
+  installPath?: string;
+  downloadUrl?: string;
 }
 
 export function configureInstaller(config: InstallerConfig): void;


### PR DESCRIPTION
With strict typings enabled, consumers are forced to specify all fields for the `Config` object, even though `configureInstaller(conf)` already handles missing fields.

Right now I have to do this

```typescript
DynamoDbLocal.configureInstaller({
    installPath: '/path/to/my/tmp',
    downloadUrl: null
});
```

when I should be able to do this

```typescript
DynamoDbLocal.configureInstaller({
    installPath: '/path/to/my/tmp'
});
```