### PR TITLE
Remove `async` keyword from stopChild in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const child = await DynamoDbLocal.launch(dynamoLocalPort, null, [], false, true)
 
 // do your tests
 
-await DynamoDbLocal.stopChild(child); // must be wrapped in async function
+DynamoDbLocal.stopChild(child);
 
 ```
 


### PR DESCRIPTION
The `stopChild` function is not asynchronous. It does not need to be `await`ed.