### PR TITLE
Fix invalid stdio

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var os = require('os'),
     spawn = require('child_process').spawn,
+    isMainThread = require('worker_threads').isMainThread,
     fs = require('fs'),
     https = require('https'),
     tar = require('tar'),
@@ -66,7 +67,7 @@ var runningProcesses = {},
                     var child = spawn('java', args, {
                         cwd: Config.installPath,
                         env: process.env,
-                        stdio: ['pipe', 'pipe', process.stderr]
+                        stdio: isMainThread ? ['pipe', 'pipe', process.stderr] : "inherit"
                     });
 
                     if (!child.pid) throw new Error('Unable to launch DynamoDBLocal process');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "./index.js",
   "engines": {
-    "node": ">= 0.10.33"
+    "node": ">= 10.5.0"
   },
   "dependencies": {
     "debug": "~4.1.0",


### PR DESCRIPTION
Spawn fails in vitest worker threaded environment.

This fix implements suggestion from vitest: https://github.com/vitest-dev/vitest/issues/1544#issuecomment-1193938332