### PR TITLE
Fix stdio setup for child process

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ var runningProcesses = {},
                     var child = spawn('java', args, {
                         cwd: Config.installPath,
                         env: process.env,
-                        stdio: ['pipe', 'pipe', process.stderr]
+                        stdio: ['ignore', 'ignore', 'inherit']
                     });
 
                     if (!child.pid) throw new Error('Unable to launch DynamoDBLocal process');


### PR DESCRIPTION
stdin and stdout should be ignored, not piped.

This seems to fix hangs when using jest-dynamodb under GitHub Actions.